### PR TITLE
Fix pattern name regular expression

### DIFF
--- a/structurizr-templates-extension/src/parser.ts
+++ b/structurizr-templates-extension/src/parser.ts
@@ -1,8 +1,8 @@
 import * as vscode from "vscode"
 
 
-const PLUGIN_APPLY_EXPR = new RegExp(/(\$pattern\s+([a-z0-9]+(\.[a-zA-Z0-9_$]+)*)(?:\s*\{[\s\S]*?\})?)/g);
-const PLUGIN_EXPR = new RegExp(/^\$pattern\s+(?<name>[a-z0-9]+(\.[a-zA-Z0-9_$]+)*)\s*(?:\{(?<params>[\s\S]*?)\})?$/gm);
+const PLUGIN_APPLY_EXPR = new RegExp(/(\$pattern\s+([a-z\.A-Z0-9]+)(?:\s*\{[\s\S]*?\})?)/g);
+const PLUGIN_EXPR = new RegExp(/^\$pattern\s+(?<name>[a-z\.A-Z0-9]+)\s*(?:\{(?<params>[\s\S]*?)\})?$/gm);
 const PARAM_EXPR = new RegExp(/^\s*(?<name>\S+)\s+(?<value>(?:['"][^'"\n]+['"])|\S+)\s*$/g);
 const UNFINISHED_PARAM_EXPR = new RegExp(/^\s*(?<name>\S+)\s*$/g);
 const STRING_BRACKETS_EXPR = new RegExp(/^['"]|['"]$/g);


### PR DESCRIPTION
Поправил регулярное выражение для определения названия паттерна. Теперь названием паттерна может быть любая последовательность латинских символом, точки или цифр.