### PR TITLE
Update base pattern class name in pattern lens

### DIFF
--- a/pattern-lens/src/main/java/io/github/nifacy/c4patterns/lens/App.java
+++ b/pattern-lens/src/main/java/io/github/nifacy/c4patterns/lens/App.java
@@ -49,7 +49,7 @@ public class App {
         String pluginsDirPath = Paths.get(workspacePath).getParent().resolve("plugins").toString();
         ClassLoader loader = initLoader(pluginsDirPath);
 
-        Optional<Class> maybeSchemaTagClass = tryLoadClass(loader, "com.patterns.params.Schema");
+        Optional<Class> maybeSchemaTagClass = tryLoadClass(loader, "io.github.nifacy.c4patterns.lib.params.Schema");
         if (!maybeSchemaTagClass.isPresent()) {
             throw new java.lang.RuntimeException("Broken patterns library: Unable to load schema base interface");
         }
@@ -66,7 +66,7 @@ public class App {
         String pluginsDirPath = Paths.get(workspacePath).getParent().resolve("plugins").toString();
         ClassLoader loader = initLoader(pluginsDirPath);
 
-        Optional<Class> basePatternClass = tryLoadClass(loader, "com.patterns.Pattern");
+        Optional<Class> basePatternClass = tryLoadClass(loader, "io.github.nifacy.c4patterns.lib.Pattern");
         if (!basePatternClass.isPresent()) {
             System.err.println("[warn] current workspace doesn't support patterns");
             return false;

--- a/pattern-lens/src/main/java/io/github/nifacy/c4patterns/lens/App.java
+++ b/pattern-lens/src/main/java/io/github/nifacy/c4patterns/lens/App.java
@@ -17,6 +17,10 @@ import io.github.nifacy.c4patterns.lens.info.PatternInfoGetter;
 
 
 public class App {
+    private static final String C4_PATTERNS_LIB_PACKAGE = "io.github.nifacy.c4patterns.lib";
+    private static final String BASE_CLASS_NAME = C4_PATTERNS_LIB_PACKAGE + ".Pattern";
+    private static final String SCHEMA_INTERFACE_CLASS_NAME = C4_PATTERNS_LIB_PACKAGE + ".params.Schema";
+
     public static void main(String[] args) {
         try {
             handleQuery(args);
@@ -49,7 +53,7 @@ public class App {
         String pluginsDirPath = Paths.get(workspacePath).getParent().resolve("plugins").toString();
         ClassLoader loader = initLoader(pluginsDirPath);
 
-        Optional<Class> maybeSchemaTagClass = tryLoadClass(loader, "io.github.nifacy.c4patterns.lib.params.Schema");
+        Optional<Class> maybeSchemaTagClass = tryLoadClass(loader, SCHEMA_INTERFACE_CLASS_NAME);
         if (!maybeSchemaTagClass.isPresent()) {
             throw new java.lang.RuntimeException("Broken patterns library: Unable to load schema base interface");
         }
@@ -66,7 +70,7 @@ public class App {
         String pluginsDirPath = Paths.get(workspacePath).getParent().resolve("plugins").toString();
         ClassLoader loader = initLoader(pluginsDirPath);
 
-        Optional<Class> basePatternClass = tryLoadClass(loader, "io.github.nifacy.c4patterns.lib.Pattern");
+        Optional<Class> basePatternClass = tryLoadClass(loader, BASE_CLASS_NAME);
         if (!basePatternClass.isPresent()) {
             System.err.println("[warn] current workspace doesn't support patterns");
             return false;


### PR DESCRIPTION
Обновил названия для базового класса паттернов `Pattern` и интерфейса для схем параметров `Schema`. Ранее, из-за неактуальных названий, Pattern Lens не мог найти эти классы, и думал, что workspace не поддерживает паттерны.